### PR TITLE
BLD: use angle bracket include for numpy

### DIFF
--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -4,9 +4,9 @@
 #include <Python.h>
 #include <math.h>
 
-#include "numpy/ndarraytypes.h"
-#include "numpy/ufuncobject.h"
-#include "numpy/npy_3kcompat.h"
+#include <numpy/ndarraytypes.h>
+#include <numpy/ufuncobject.h>
+#include <numpy/npy_3kcompat.h>
 
 #include "geos.h"
 #include "pygeom.h"


### PR DESCRIPTION
This doesn't fix any build issue I am having (I thought for a moment this would fix a conda-forge problem, but it seems not to fix it), but, from seeing other projects (arrow, pandas), this seems to be the way they include numpy (look on the canonical include dirs, not first in the local directory).