### PR TITLE
Refactor ufuncs module into lib module

### DIFF
--- a/pygeos/__init__.py
+++ b/pygeos/__init__.py
@@ -1,6 +1,6 @@
-from .ufuncs import GEOSException  # NOQA
-from .ufuncs import Geometry  # NOQA
-from .ufuncs import geos_version  # NOQA
+from .lib import GEOSException  # NOQA
+from .lib import Geometry  # NOQA
+from .lib import geos_version  # NOQA
 from .geometry import *
 from .creation import *
 from .constructive import *

--- a/pygeos/constructive.py
+++ b/pygeos/constructive.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 import numpy as np
 from . import Geometry  # NOQA
-from . import ufuncs
+from . import lib
 
 
 __all__ = [
@@ -54,7 +54,7 @@ def boundary(geometry, **kwargs):
     >>> boundary(Geometry("MULTIPOINT (0 0, 1 2)")) is None
     True
     """
-    return ufuncs.boundary(geometry, **kwargs)
+    return lib.boundary(geometry, **kwargs)
 
 
 def buffer(
@@ -147,7 +147,7 @@ def buffer(
         raise TypeError("mitre_limit only accepts scalar values")
     if not np.isscalar(single_sided):
         raise TypeError("single_sided only accepts scalar values")
-    return ufuncs.buffer(
+    return lib.buffer(
         geometry,
         radius,
         np.intc(quadsegs),
@@ -180,7 +180,7 @@ def centroid(geometry, **kwargs):
     >>> centroid(Geometry("MULTIPOINT (0 0, 10 10)"))
     <pygeos.Geometry POINT (5 5)>
     """
-    return ufuncs.centroid(geometry, **kwargs)
+    return lib.centroid(geometry, **kwargs)
 
 
 def convex_hull(geometry, **kwargs):
@@ -197,7 +197,7 @@ def convex_hull(geometry, **kwargs):
     >>> convex_hull(Geometry("POLYGON EMPTY"))
     <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>
     """
-    return ufuncs.convex_hull(geometry, **kwargs)
+    return lib.convex_hull(geometry, **kwargs)
 
 
 def delaunay_triangles(geometry, tolerance=0.0, only_edges=False, **kwargs):
@@ -233,7 +233,7 @@ def delaunay_triangles(geometry, tolerance=0.0, only_edges=False, **kwargs):
     >>> delaunay_triangles(Geometry("GEOMETRYCOLLECTION EMPTY"))
     <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>
     """
-    return ufuncs.delaunay_triangles(geometry, tolerance, only_edges, **kwargs)
+    return lib.delaunay_triangles(geometry, tolerance, only_edges, **kwargs)
 
 
 def envelope(geometry, **kwargs):
@@ -254,7 +254,7 @@ def envelope(geometry, **kwargs):
     >>> envelope(Geometry("GEOMETRYCOLLECTION EMPTY"))
     <pygeos.Geometry POINT EMPTY>
     """
-    return ufuncs.envelope(geometry, **kwargs)
+    return lib.envelope(geometry, **kwargs)
 
 
 def extract_unique_points(geometry, **kwargs):
@@ -280,7 +280,7 @@ def extract_unique_points(geometry, **kwargs):
     >>> extract_unique_points(Geometry("LINESTRING EMPTY"))
     <pygeos.Geometry MULTIPOINT EMPTY>
     """
-    return ufuncs.extract_unique_points(geometry, **kwargs)
+    return lib.extract_unique_points(geometry, **kwargs)
 
 
 def point_on_surface(geometry, **kwargs):
@@ -301,7 +301,7 @@ def point_on_surface(geometry, **kwargs):
     >>> point_on_surface(Geometry("POLYGON EMPTY"))
     <pygeos.Geometry POINT EMPTY>
     """
-    return ufuncs.point_on_surface(geometry, **kwargs)
+    return lib.point_on_surface(geometry, **kwargs)
 
 
 def simplify(geometry, tolerance, preserve_topology=False, **kwargs):
@@ -331,9 +331,9 @@ def simplify(geometry, tolerance, preserve_topology=False, **kwargs):
     <pygeos.Geometry POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))>
     """
     if preserve_topology:
-        return ufuncs.simplify_preserve_topology(geometry, tolerance, **kwargs)
+        return lib.simplify_preserve_topology(geometry, tolerance, **kwargs)
     else:
-        return ufuncs.simplify(geometry, tolerance, **kwargs)
+        return lib.simplify(geometry, tolerance, **kwargs)
 
 
 def snap(geometry, reference, tolerance, **kwargs):
@@ -362,7 +362,7 @@ def snap(geometry, reference, tolerance, **kwargs):
     >>> snap(polygon, Geometry("LINESTRING (8 10, 8 0)"), tolerance=5)
     <pygeos.Geometry POLYGON ((0 0, 0 10, 8 10, 8 0, 0 0))>
     """
-    return ufuncs.snap(geometry, reference, tolerance, **kwargs)
+    return lib.snap(geometry, reference, tolerance, **kwargs)
 
 
 def voronoi_polygons(
@@ -402,4 +402,4 @@ def voronoi_polygons(
     >>> voronoi_polygons(Geometry("POINT (2 2)"))
     <pygeos.Geometry GEOMETRYCOLLECTION EMPTY>
     """
-    return ufuncs.voronoi_polygons(geometry, tolerance, extend_to, only_edges, **kwargs)
+    return lib.voronoi_polygons(geometry, tolerance, extend_to, only_edges, **kwargs)

--- a/pygeos/creation.py
+++ b/pygeos/creation.py
@@ -1,5 +1,5 @@
 import numpy as np
-from . import ufuncs
+from . import lib
 from . import Geometry, GeometryType
 
 __all__ = [
@@ -37,7 +37,7 @@ def points(coords, y=None, z=None):
     y : array_like
     z : array_like
     """
-    return _wrap_construct_ufunc(ufuncs.points, coords, y, z)
+    return _wrap_construct_ufunc(lib.points, coords, y, z)
 
 
 def linestrings(coords, y=None, z=None):
@@ -51,7 +51,7 @@ def linestrings(coords, y=None, z=None):
     y : array_like
     z : array_like
     """
-    return _wrap_construct_ufunc(ufuncs.linestrings, coords, y, z)
+    return _wrap_construct_ufunc(lib.linestrings, coords, y, z)
 
 
 def linearrings(coords, y=None, z=None):
@@ -68,7 +68,7 @@ def linearrings(coords, y=None, z=None):
     y : array_like
     z : array_like
     """
-    return _wrap_construct_ufunc(ufuncs.linearrings, coords, y, z)
+    return _wrap_construct_ufunc(lib.linearrings, coords, y, z)
 
 
 def polygons(shells, holes=None):
@@ -87,12 +87,12 @@ def polygons(shells, holes=None):
         shells = linearrings(shells)
 
     if holes is None:
-        return ufuncs.polygons_without_holes(shells)
+        return lib.polygons_without_holes(shells)
 
     holes = np.asarray(holes)
     if not isinstance(holes, Geometry) and np.issubdtype(holes.dtype, np.number):
         holes = linearrings(holes)
-    return ufuncs.polygons_with_holes(shells, holes)
+    return lib.polygons_with_holes(shells, holes)
 
 
 def box(x1, y1, x2, y2):
@@ -125,7 +125,7 @@ def multipoints(geometries):
         geometries.dtype, np.number
     ):
         geometries = points(geometries)
-    return ufuncs.create_collection(geometries, GeometryType.MULTIPOINT)
+    return lib.create_collection(geometries, GeometryType.MULTIPOINT)
 
 
 def multilinestrings(geometries):
@@ -141,7 +141,7 @@ def multilinestrings(geometries):
         geometries.dtype, np.number
     ):
         geometries = linestrings(geometries)
-    return ufuncs.create_collection(geometries, GeometryType.MULTILINESTRING)
+    return lib.create_collection(geometries, GeometryType.MULTILINESTRING)
 
 
 def multipolygons(geometries):
@@ -157,7 +157,7 @@ def multipolygons(geometries):
         geometries.dtype, np.number
     ):
         geometries = polygons(geometries)
-    return ufuncs.create_collection(geometries, GeometryType.MULTIPOLYGON)
+    return lib.create_collection(geometries, GeometryType.MULTIPOLYGON)
 
 
 def geometrycollections(geometries):
@@ -168,4 +168,4 @@ def geometrycollections(geometries):
     geometries : array_like
         An array of geometries
     """
-    return ufuncs.create_collection(geometries, GeometryType.GEOMETRYCOLLECTION)
+    return lib.create_collection(geometries, GeometryType.GEOMETRYCOLLECTION)

--- a/pygeos/geometry.py
+++ b/pygeos/geometry.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 import numpy as np
-from . import ufuncs
+from . import lib
 from . import Geometry  # NOQA
 
 __all__ = [
@@ -68,7 +68,7 @@ def get_type_id(geometry):
     >>> get_type_id([Geometry("POINT (1 2)"), Geometry("POINT (1 2)")]).tolist()
     [0, 0]
     """
-    return ufuncs.get_type_id(geometry)
+    return lib.get_type_id(geometry)
 
 
 def get_dimensions(geometry):
@@ -95,7 +95,7 @@ def get_dimensions(geometry):
     >>> get_dimensions(None)
     -1
     """
-    return ufuncs.get_dimensions(geometry)
+    return lib.get_dimensions(geometry)
 
 
 def get_coordinate_dimensions(geometry):
@@ -116,7 +116,7 @@ def get_coordinate_dimensions(geometry):
     >>> get_coordinate_dimensions(None)
     -1
     """
-    return ufuncs.get_coordinate_dimensions(geometry)
+    return lib.get_coordinate_dimensions(geometry)
 
 
 def get_num_coordinates(geometry):
@@ -139,7 +139,7 @@ def get_num_coordinates(geometry):
     >>> get_num_coordinates(None)
     -1
     """
-    return ufuncs.get_num_coordinates(geometry)
+    return lib.get_num_coordinates(geometry)
 
 
 def get_srid(geometry):
@@ -164,7 +164,7 @@ def get_srid(geometry):
     >>> get_srid(with_srid)
     4326
     """
-    return ufuncs.get_srid(geometry)
+    return lib.get_srid(geometry)
 
 
 def set_srid(geometry, srid):
@@ -188,7 +188,7 @@ def set_srid(geometry, srid):
     >>> get_srid(with_srid)
     4326
     """
-    return ufuncs.set_srid(geometry, np.intc(srid))
+    return lib.set_srid(geometry, np.intc(srid))
 
 
 # points
@@ -213,7 +213,7 @@ def get_x(point):
     >>> get_x(Geometry("MULTIPOINT (1 1, 1 2)"))
     nan
     """
-    return ufuncs.get_x(point)
+    return lib.get_x(point)
 
 
 def get_y(point):
@@ -235,7 +235,7 @@ def get_y(point):
     >>> get_y(Geometry("MULTIPOINT (1 1, 1 2)"))
     nan
     """
-    return ufuncs.get_y(point)
+    return lib.get_y(point)
 
 
 # linestrings
@@ -270,7 +270,7 @@ def get_point(geometry, index):
     >>> get_point(Geometry("POINT (1 1)"), 0) is None
     True
     """
-    return ufuncs.get_point(geometry, np.intc(index))
+    return lib.get_point(geometry, np.intc(index))
 
 
 def get_num_points(geometry):
@@ -295,7 +295,7 @@ def get_num_points(geometry):
     >>> get_num_points(Geometry("MULTIPOINT (0 0, 1 1, 2 2, 3 3)"))
     0
     """
-    return ufuncs.get_num_points(geometry)
+    return lib.get_num_points(geometry)
 
 
 # polygons
@@ -319,7 +319,7 @@ def get_exterior_ring(geometry):
     >>> get_exterior_ring(Geometry("POINT (1 1)")) is None
     True
     """
-    return ufuncs.get_exterior_ring(geometry)
+    return lib.get_exterior_ring(geometry)
 
 
 def get_interior_ring(geometry, index):
@@ -344,7 +344,7 @@ def get_interior_ring(geometry, index):
     >>> get_interior_ring(Geometry("POINT (1 1)"), 0) is None
     True
     """
-    return ufuncs.get_interior_ring(geometry, np.intc(index))
+    return lib.get_interior_ring(geometry, np.intc(index))
 
 
 def get_num_interior_rings(geometry):
@@ -371,7 +371,7 @@ def get_num_interior_rings(geometry):
     >>> get_num_interior_rings(Geometry("POINT (1 1)"))
     0
     """
-    return ufuncs.get_num_interior_rings(geometry)
+    return lib.get_num_interior_rings(geometry)
 
 
 # collections
@@ -409,7 +409,7 @@ def get_geometry(geometry, index):
     >>> get_geometry(Geometry("POINT (1 1)"), 1) is None
     True
     """
-    return ufuncs.get_geometry(geometry, np.intc(index))
+    return lib.get_geometry(geometry, np.intc(index))
 
 
 def get_num_geometries(geometry):
@@ -433,4 +433,4 @@ def get_num_geometries(geometry):
     >>> get_num_geometries(Geometry("POINT (1 1)"))
     1
     """
-    return ufuncs.get_num_geometries(geometry)
+    return lib.get_num_geometries(geometry)

--- a/pygeos/linear.py
+++ b/pygeos/linear.py
@@ -1,28 +1,28 @@
-from . import ufuncs
+from . import lib
 
 __all__ = ["interpolate", "line_merge", "project", "shared_paths"]
 
 
 def interpolate(line, normalize=False):
     if normalize:
-        return ufuncs.interpolate_normalized(line)
+        return lib.interpolate_normalized(line)
     else:
-        return ufuncs.interpolate(line)
+        return lib.interpolate(line)
 
 
 def line_merge(lines):
-    return ufuncs.line_merge(lines)
+    return lib.line_merge(lines)
 
 
 def project(line, other, normalize=False):
     if normalize:
-        return ufuncs.project_normalized(line, other)
+        return lib.project_normalized(line, other)
     else:
-        return ufuncs.project(line, other)
+        return lib.project(line, other)
 
 
 def shared_paths(a, b=None, axis=0):
     if b is None:
-        return ufuncs.shared_paths.reduce(a, axis=axis)
+        return lib.shared_paths.reduce(a, axis=axis)
     else:
-        return ufuncs.shared_paths(a, b)
+        return lib.shared_paths(a, b)

--- a/pygeos/measurement.py
+++ b/pygeos/measurement.py
@@ -1,4 +1,4 @@
-from . import ufuncs
+from . import lib
 from . import Geometry  # NOQA
 
 __all__ = ["area", "distance", "length", "hausdorff_distance"]
@@ -22,7 +22,7 @@ def area(geometry):
     >>> area(None)
     nan
     """
-    return ufuncs.area(geometry)
+    return lib.area(geometry)
 
 
 def distance(a, b):
@@ -46,7 +46,7 @@ def distance(a, b):
     >>> distance(None, point)
     nan
     """
-    return ufuncs.distance(a, b)
+    return lib.distance(a, b)
 
 
 def length(geometry):
@@ -69,7 +69,7 @@ def length(geometry):
     >>> length(None)
     nan
     """
-    return ufuncs.length(geometry)
+    return lib.length(geometry)
 
 
 def hausdorff_distance(a, b, densify=None):
@@ -101,6 +101,6 @@ def hausdorff_distance(a, b, densify=None):
     nan
     """
     if densify is None:
-        return ufuncs.hausdorff_distance(a, b)
+        return lib.hausdorff_distance(a, b)
     else:
-        return ufuncs.haussdorf_distance_densify(a, b, densify)
+        return lib.haussdorf_distance_densify(a, b, densify)

--- a/pygeos/predicates.py
+++ b/pygeos/predicates.py
@@ -1,6 +1,6 @@
 import warnings
 
-from . import ufuncs
+from . import lib
 from . import Geometry  # NOQA
 
 __all__ = [
@@ -41,7 +41,7 @@ def has_z(geometry, **kwargs):
     >>> has_z(Geometry("POINT Z (0 0 0)"))
     True
     """
-    return ufuncs.has_z(geometry, **kwargs)
+    return lib.has_z(geometry, **kwargs)
 
 
 def is_closed(geometry, **kwargs):
@@ -65,7 +65,7 @@ def is_closed(geometry, **kwargs):
     >>> is_closed(Geometry("POINT (0 0)"))
     False
     """
-    return ufuncs.is_closed(geometry, **kwargs)
+    return lib.is_closed(geometry, **kwargs)
 
 
 def is_empty(geometry, **kwargs):
@@ -89,7 +89,7 @@ def is_empty(geometry, **kwargs):
     >>> is_empty(None)
     False
     """
-    return ufuncs.is_empty(geometry, **kwargs)
+    return lib.is_empty(geometry, **kwargs)
 
 
 def is_geometry(geometry, **kwargs):
@@ -115,7 +115,7 @@ def is_geometry(geometry, **kwargs):
     >>> is_geometry("text")
     False
     """
-    return ufuncs.is_geometry(geometry, **kwargs)
+    return lib.is_geometry(geometry, **kwargs)
 
 
 def is_missing(geometry, **kwargs):
@@ -142,7 +142,7 @@ def is_missing(geometry, **kwargs):
     >>> is_missing("text")
     False
     """
-    return ufuncs.is_missing(geometry, **kwargs)
+    return lib.is_missing(geometry, **kwargs)
 
 
 def is_valid_input(geometry, **kwargs):
@@ -170,7 +170,7 @@ def is_valid_input(geometry, **kwargs):
     >>> is_valid_input("text")
     False
     """
-    return ufuncs.is_valid_input(geometry, **kwargs)
+    return lib.is_valid_input(geometry, **kwargs)
 
 
 def is_ring(geometry, **kwargs):
@@ -200,7 +200,7 @@ def is_ring(geometry, **kwargs):
     >>> is_closed(geom), is_simple(geom), is_ring(geom)
     (True, False, False)
     """
-    return ufuncs.is_ring(geometry, **kwargs)
+    return lib.is_ring(geometry, **kwargs)
 
 
 def is_simple(geometry, **kwargs):
@@ -225,7 +225,7 @@ def is_simple(geometry, **kwargs):
     >>> is_simple(None)
     False
     """
-    return ufuncs.is_simple(geometry, **kwargs)
+    return lib.is_simple(geometry, **kwargs)
 
 
 def is_valid(geometry, **kwargs):
@@ -254,7 +254,7 @@ def is_valid(geometry, **kwargs):
     # GEOS is valid will emit warnings for invalid geometries. Suppress them.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        result = ufuncs.is_valid(geometry, **kwargs)
+        result = lib.is_valid(geometry, **kwargs)
     return result
 
 
@@ -279,7 +279,7 @@ def is_valid_reason(geometry, **kwargs):
     >>> is_valid_reason(None) is None
     True
     """
-    return ufuncs.is_valid_reason(geometry, **kwargs)
+    return lib.is_valid_reason(geometry, **kwargs)
 
 
 def crosses(a, b, **kwargs):
@@ -316,7 +316,7 @@ def crosses(a, b, **kwargs):
     >>> crosses(area, Geometry("MULTIPOINT ((2 2), (0.5 0.5))"))
     True
     """
-    return ufuncs.crosses(a, b, **kwargs)
+    return lib.crosses(a, b, **kwargs)
 
 
 def contains(a, b, **kwargs):
@@ -359,7 +359,7 @@ def contains(a, b, **kwargs):
     >>> contains(area, None)
     False
     """
-    return ufuncs.contains(a, b, **kwargs)
+    return lib.contains(a, b, **kwargs)
 
 
 def covered_by(a, b, **kwargs):
@@ -399,7 +399,7 @@ def covered_by(a, b, **kwargs):
     >>> covered_by(None, area)
     False
     """
-    return ufuncs.covered_by(a, b, **kwargs)
+    return lib.covered_by(a, b, **kwargs)
 
 
 def covers(a, b, **kwargs):
@@ -439,7 +439,7 @@ def covers(a, b, **kwargs):
     >>> covers(area, None)
     False
     """
-    return ufuncs.covers(a, b, **kwargs)
+    return lib.covers(a, b, **kwargs)
 
 
 def disjoint(a, b, **kwargs):
@@ -475,7 +475,7 @@ def disjoint(a, b, **kwargs):
     >>> disjoint(None, None)
     False
     """
-    return ufuncs.disjoint(a, b, **kwargs)
+    return lib.disjoint(a, b, **kwargs)
 
 
 def equals(a, b, tolerance=0.0, **kwargs):
@@ -504,9 +504,9 @@ def equals(a, b, tolerance=0.0, **kwargs):
     False
     """
     if tolerance > 0.0:
-        return ufuncs.equals_exact(a, b, tolerance, **kwargs)
+        return lib.equals_exact(a, b, tolerance, **kwargs)
     else:
-        return ufuncs.equals(a, b, **kwargs)
+        return lib.equals(a, b, **kwargs)
 
 
 def intersects(a, b, **kwargs):
@@ -534,7 +534,7 @@ def intersects(a, b, **kwargs):
     >>> intersects(None, None)
     False
     """
-    return ufuncs.intersects(a, b, **kwargs)
+    return lib.intersects(a, b, **kwargs)
 
 
 def overlaps(a, b, **kwargs):
@@ -559,7 +559,7 @@ def overlaps(a, b, **kwargs):
     >>> overlaps(None, None)
     False
     """
-    return ufuncs.overlaps(a, b, **kwargs)
+    return lib.overlaps(a, b, **kwargs)
 
 
 def touches(a, b, **kwargs):
@@ -591,7 +591,7 @@ def touches(a, b, **kwargs):
     >>> touches(area, Geometry("POLYGON((0 1, 1 1, 1 2, 0 2, 0 1))"))
     True
     """
-    return ufuncs.touches(a, b, **kwargs)
+    return lib.touches(a, b, **kwargs)
 
 
 def within(a, b, **kwargs):
@@ -634,4 +634,4 @@ def within(a, b, **kwargs):
     >>> within(None, area)
     False
     """
-    return ufuncs.within(a, b, **kwargs)
+    return lib.within(a, b, **kwargs)

--- a/pygeos/set_operations.py
+++ b/pygeos/set_operations.py
@@ -1,5 +1,5 @@
 import numpy as np
-from . import ufuncs, Geometry, GeometryType
+from . import lib, Geometry, GeometryType
 
 __all__ = [
     "difference",
@@ -30,7 +30,7 @@ def difference(a, b, **kwargs):
     >>> difference(line, None) is None
     True
     """
-    return ufuncs.difference(a, b, **kwargs)
+    return lib.difference(a, b, **kwargs)
 
 
 def intersection(a, b, **kwargs):
@@ -51,7 +51,7 @@ def intersection(a, b, **kwargs):
     >>> intersection(line, Geometry("LINESTRING(1 1, 3 3)"))
     <pygeos.Geometry LINESTRING (1 1, 2 2)>
     """
-    return ufuncs.intersection(a, b, **kwargs)
+    return lib.intersection(a, b, **kwargs)
 
 
 def intersection_all(geometries, axis=0, **kwargs):
@@ -79,7 +79,7 @@ def intersection_all(geometries, axis=0, **kwargs):
     >>> intersection_all([[line_1, line_2, None]], axis=1).tolist()
     [None]
     """
-    return ufuncs.intersection.reduce(geometries, axis=axis, **kwargs)
+    return lib.intersection.reduce(geometries, axis=axis, **kwargs)
 
 
 def symmetric_difference(a, b, **kwargs):
@@ -101,7 +101,7 @@ def symmetric_difference(a, b, **kwargs):
     >>> symmetric_difference(line, Geometry("LINESTRING(1 1, 3 3)"))
     <pygeos.Geometry MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))>
     """
-    return ufuncs.symmetric_difference(a, b, **kwargs)
+    return lib.symmetric_difference(a, b, **kwargs)
 
 
 def symmetric_difference_all(geometries, axis=0, **kwargs):
@@ -129,7 +129,7 @@ def symmetric_difference_all(geometries, axis=0, **kwargs):
     >>> symmetric_difference_all([[line_1, line_2, None]], axis=1).tolist()
     [None]
     """
-    return ufuncs.symmetric_difference.reduce(geometries, axis=axis, **kwargs)
+    return lib.symmetric_difference.reduce(geometries, axis=axis, **kwargs)
 
 
 def union(a, b, **kwargs):
@@ -152,7 +152,7 @@ def union(a, b, **kwargs):
     >>> union(line, None) is None
     True
     """
-    return ufuncs.union(a, b, **kwargs)
+    return lib.union(a, b, **kwargs)
 
 
 def union_all(geometries, axis=0, **kwargs):
@@ -191,5 +191,5 @@ def union_all(geometries, axis=0, **kwargs):
             np.asarray(geometries), axis=axis, start=geometries.ndim
         )
     # create_collection acts on the inner axis
-    collections = ufuncs.create_collection(geometries, GeometryType.GEOMETRYCOLLECTION)
-    return ufuncs.unary_union(collections, **kwargs)
+    collections = lib.create_collection(geometries, GeometryType.GEOMETRYCOLLECTION)
+    return lib.unary_union(collections, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ class build_ext(_build_ext):
 
 
 module_ufuncs = Extension(
-    "pygeos.ufuncs", sources=["src/ufuncs.c", "src/pygeom.c"], **get_geos_paths())
+    "pygeos.lib", sources=["src/lib.c", "src/geos.c", "src/pygeom.c"], **get_geos_paths())
 
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,11 @@ class build_ext(_build_ext):
         self.include_dirs.append(numpy.get_include())
 
 
-module_ufuncs = Extension(
-    "pygeos.lib", sources=["src/lib.c", "src/geos.c", "src/pygeom.c"], **get_geos_paths())
+module_lib = Extension(
+    "pygeos.lib",
+    sources=["src/lib.c", "src/geos.c", "src/pygeom.c", "src/ufuncs.c"],
+    **get_geos_paths()
+)
 
 
 try:
@@ -135,7 +138,7 @@ setup(
     extras_require={"test": ["pytest"], "docs": ["sphinx", "numpydoc"]},
     python_requires=">=3",
     include_package_data=True,
-    ext_modules=[module_ufuncs],
+    ext_modules=[module_lib],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Development Status :: 1 - Planning",

--- a/src/geos.c
+++ b/src/geos.c
@@ -1,0 +1,29 @@
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <Python.h>
+#include <structmember.h>
+
+#include "geos.h"
+
+/* This initializes a global GEOS Context */
+void *geos_context[1] = {NULL};
+
+static void HandleGEOSError(const char *message, void *userdata) {
+    PyErr_SetString(userdata, message);
+}
+
+static void HandleGEOSNotice(const char *message, void *userdata) {
+    PyErr_WarnEx(PyExc_Warning, message, 1);
+}
+
+int init_geos(PyObject *m)
+{
+    void *context_handle = GEOS_init_r();
+    PyObject* GEOSException = PyErr_NewException("pygeos.GEOSException", NULL, NULL);
+    PyModule_AddObject(m, "GEOSException", GEOSException);
+    GEOSContext_setErrorMessageHandler_r(context_handle, HandleGEOSError, GEOSException);
+    GEOSContext_setNoticeMessageHandler_r(context_handle, HandleGEOSNotice, NULL);
+    geos_context[0] = context_handle;  /* for global access */
+    return 0;
+}

--- a/src/geos.h
+++ b/src/geos.h
@@ -9,4 +9,6 @@
 /* This declares a global GEOS Context */
 extern void *geos_context[1];
 
+int init_geos(PyObject *m);
+
 #endif

--- a/src/lib.c
+++ b/src/lib.c
@@ -1,0 +1,64 @@
+#define PY_SSIZE_T_CLEAN
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <Python.h>
+
+#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+#include <numpy/ndarraytypes.h>
+#include <numpy/ufuncobject.h>
+#include <numpy/npy_3kcompat.h>
+
+#include "geos.h"
+#include "pygeom.h"
+#include "ufuncs.h"
+
+
+/* This tells Python what methods this module has. */
+static PyMethodDef GeosModule[] = {
+    {NULL, NULL, 0, NULL},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "lib",
+    NULL,
+    -1,
+    GeosModule,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC PyInit_lib(void)
+{
+    PyObject *m, *d;
+
+    m = PyModule_Create(&moduledef);
+    if (!m) {
+        return NULL;
+    }
+
+    if (init_geos(m) < 0){
+        return NULL;
+    };
+
+    if (init_geom_type(m) < 0){
+        return NULL;
+    };
+
+    d = PyModule_GetDict(m);
+
+    import_array();
+    import_umath();
+
+    /* export the version as a python string */
+    PyModule_AddObject(m, "geos_version", PyUnicode_FromString(GEOS_VERSION));
+
+    if (init_ufuncs(m, d) < 0){
+        return NULL;
+    };
+
+    return m;
+}

--- a/src/lib.c
+++ b/src/lib.c
@@ -10,7 +10,9 @@
 
 #include "geos.h"
 #include "pygeom.h"
-#include "ufuncs.h"
+
+/* include ufuncs.c directly instead of linking it */
+#include "ufuncs.c"
 
 
 /* This tells Python what methods this module has. */

--- a/src/lib.c
+++ b/src/lib.c
@@ -4,15 +4,14 @@
 #include <Python.h>
 
 #define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+#define PY_UFUNC_UNIQUE_SYMBOL pygeos_UFUNC_API
 #include <numpy/ndarraytypes.h>
 #include <numpy/ufuncobject.h>
 #include <numpy/npy_3kcompat.h>
 
 #include "geos.h"
 #include "pygeom.h"
-
-/* include ufuncs.c directly instead of linking it */
-#include "ufuncs.c"
+#include "ufuncs.h"
 
 
 /* This tells Python what methods this module has. */

--- a/src/lib.c
+++ b/src/lib.c
@@ -41,11 +41,11 @@ PyMODINIT_FUNC PyInit_lib(void)
         return NULL;
     }
 
-    if (init_geos(m) < 0){
+    if (init_geos(m) < 0) {
         return NULL;
     };
 
-    if (init_geom_type(m) < 0){
+    if (init_geom_type(m) < 0) {
         return NULL;
     };
 
@@ -57,7 +57,7 @@ PyMODINIT_FUNC PyInit_lib(void)
     /* export the version as a python string */
     PyModule_AddObject(m, "geos_version", PyUnicode_FromString(GEOS_VERSION));
 
-    if (init_ufuncs(m, d) < 0){
+    if (init_ufuncs(m, d) < 0) {
         return NULL;
     };
 

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -254,7 +254,7 @@ static PyMethodDef GeometryObject_methods[] = {
 
 PyTypeObject GeometryType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "pygeos.ufuncs.GEOSGeometry",
+    .tp_name = "pygeos.lib.GEOSGeometry",
     .tp_doc = "Geometry type",
     .tp_basicsize = sizeof(GeometryObject),
     .tp_itemsize = 0,
@@ -265,6 +265,24 @@ PyTypeObject GeometryType = {
     .tp_methods = GeometryObject_methods,
     .tp_repr = (reprfunc) GeometryObject_repr,
 };
+
+
+/* Get a GEOSGeometry pointer from a GeometryObject, or NULL if the input is
+Py_None. Returns 0 on error, 1 on success. */
+char get_geom(GeometryObject *obj, GEOSGeometry **out) {
+    if (!PyObject_IsInstance((PyObject *) obj, (PyObject *) &GeometryType)) {
+        if ((PyObject *) obj == Py_None) {
+            *out = NULL;
+            return 1;
+        } else {
+            PyErr_Format(PyExc_TypeError, "One of the arguments is of incorrect type. Please provide only Geometry objects.");
+            return 0;
+        }
+    } else {
+        *out = obj->ptr;
+        return 1;
+    }
+}
 
 int
 init_geom_type(PyObject *m)

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -287,8 +287,9 @@ char get_geom(GeometryObject *obj, GEOSGeometry **out) {
 int
 init_geom_type(PyObject *m)
 {
-    if (PyType_Ready(&GeometryType) < 0)
+    if (PyType_Ready(&GeometryType) < 0) {
         return -1;
+    }
 
     Py_INCREF(&GeometryType);
     PyModule_AddObject(m, "Geometry", (PyObject *) &GeometryType);

--- a/src/pygeom.h
+++ b/src/pygeom.h
@@ -11,12 +11,12 @@ typedef struct {
 } GeometryObject;
 
 
-GeometryObject *NaG;
-
 PyTypeObject GeometryType;
 
 /* Initializes a new geometry object */
 PyObject *GeometryObject_FromGEOS(PyTypeObject *type, GEOSGeometry *ptr);
+/* Get a GEOSGeometry from a GeometryObject */
+extern char get_geom(GeometryObject *obj, GEOSGeometry **out);
 
 int init_geom_type(PyObject *m);
 

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -1,6 +1,3 @@
-#ifndef _UFUNCS_H
-#define _UFUNCS_H
-
 #define PY_SSIZE_T_CLEAN
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
@@ -1048,5 +1045,3 @@ int init_ufuncs(PyObject *m, PyObject *d)
     Py_DECREF(ufunc);
     return 0;
 }
-
-#endif

--- a/src/ufuncs.c
+++ b/src/ufuncs.c
@@ -5,7 +5,9 @@
 #include <math.h>
 
 #define NO_IMPORT_ARRAY
+#define NO_IMPORT_UFUNC
 #define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
+#define PY_UFUNC_UNIQUE_SYMBOL pygeos_UFUNC_API
 #include <numpy/ndarraytypes.h>
 #include <numpy/ufuncobject.h>
 #include <numpy/npy_3kcompat.h>

--- a/src/ufuncs.h
+++ b/src/ufuncs.h
@@ -1,9 +1,14 @@
+#ifndef _UFUNCS_H
+#define _UFUNCS_H
+
 #define PY_SSIZE_T_CLEAN
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include <Python.h>
 #include <math.h>
 
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL pygeos_ARRAY_API
 #include <numpy/ndarraytypes.h>
 #include <numpy/ufuncobject.h>
 #include <numpy/npy_3kcompat.h>
@@ -32,39 +37,6 @@
     PyObject **out = (PyObject **)op1;\
     Py_XDECREF(*out);\
     *out = ret
-
-/* This tells Python what methods this module has. */
-static PyMethodDef GeosModule[] = {
-    {NULL, NULL, 0, NULL},
-    {NULL, NULL, 0, NULL}
-};
-
-/* This initializes a global GEOS Context */
-void *geos_context[1] = {NULL};
-
-static void HandleGEOSError(const char *message, void *userdata) {
-    PyErr_SetString(userdata, message);
-}
-
-static void HandleGEOSNotice(const char *message, void *userdata) {
-    PyErr_WarnEx(PyExc_Warning, message, 1);
-}
-
-
-static char get_geom(GeometryObject *obj, GEOSGeometry **out) {
-    if (!PyObject_IsInstance((PyObject *) obj, (PyObject *) &GeometryType)) {
-        if ((PyObject *) obj == Py_None) {
-            *out = NULL;
-            return 1;
-        } else {
-            PyErr_Format(PyExc_TypeError, "One of the arguments is of incorrect type. Please provide only Geometry objects.");
-            return 0;
-        }
-    } else {
-        *out = obj->ptr;
-        return 1;
-    }
-}
 
 /* Define the geom -> bool functions (Y_b) */
 static void *is_empty_data[1] = {GEOSisEmpty_r};
@@ -987,45 +959,9 @@ TODO relate functions
     ufunc = PyUFunc_FromFuncAndDataAndSignature(NAME ##_funcs, null_data, NAME ##_dtypes, 1, N_IN, 1, PyUFunc_None, # NAME, "", 0, SIGNATURE);\
     PyDict_SetItemString(d, # NAME, ufunc)
 
-static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "ufuncs",
-    NULL,
-    -1,
-    GeosModule,
-    NULL,
-    NULL,
-    NULL,
-    NULL
-};
-
-PyMODINIT_FUNC PyInit_ufuncs(void)
+int init_ufuncs(PyObject *m, PyObject *d)
 {
-    PyObject *m, *d, *ufunc;
-
-    m = PyModule_Create(&moduledef);
-    if (!m) {
-        return NULL;
-    }
-
-    if (init_geom_type(m) < 0){
-        return NULL;
-    };
-
-    d = PyModule_GetDict(m);
-
-    import_array();
-    import_umath();
-
-    void *context_handle = GEOS_init_r();
-    PyObject* GEOSException = PyErr_NewException("pygeos.GEOSException", NULL, NULL);
-    PyModule_AddObject(m, "GEOSException", GEOSException);
-    GEOSContext_setErrorMessageHandler_r(context_handle, HandleGEOSError, GEOSException);
-    GEOSContext_setNoticeMessageHandler_r(context_handle, HandleGEOSNotice, NULL);
-    geos_context[0] = context_handle;  /* for global access */
-
-    /* export the version as a python string */
-    PyModule_AddObject(m, "geos_version", PyUnicode_FromString(GEOS_VERSION));
+    PyObject *ufunc;
 
     DEFINE_Y_b (is_empty);
     DEFINE_Y_b (is_simple);
@@ -1110,5 +1046,7 @@ PyMODINIT_FUNC PyInit_ufuncs(void)
     DEFINE_GENERALIZED(create_collection, 2, "(i),()->()");
 
     Py_DECREF(ufunc);
-    return m;
+    return 0;
 }
+
+#endif

--- a/src/ufuncs.h
+++ b/src/ufuncs.h
@@ -1,0 +1,9 @@
+#ifndef _UFUNCS_H
+#define _UFUNCS_H
+
+#include <Python.h>
+
+
+int init_ufuncs(PyObject *m, PyObject *d);
+
+#endif


### PR DESCRIPTION
@caspervdw I started this afternoon to try to split the files a bit more and have a separate ufuncs file and a general `lib` module instead of `ufuncs` (since not everything are ufuncs, I think mentioned it before on some PR, not sure if you are OK with that?).

Then I saw that you also did some changes to move out geos things into geos.c / pygeom.c in the coordinates PR, and included that here as well to see if all is working.

One thing that I ran into is that the ufunc registry functions don't copy the passed arguments, and you need to ensure that all those objects are kept alive as long as the ufunc objects exist. That caused segfaults when calling `init_ufuncs` defined in `ufuncs.c` from `lib.c` (as all those arguments where not declared in ufuncs.h, only the init function, I suppose). For now I "fixed" this by just having a ufuncs.h and including that fully instead of a ufuncs.c + ufuncs.h.